### PR TITLE
chore :  Use BooleanSupplier in parameterized test parameter in OpenShiftHelperStatusTest

### DIFF
--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/OpenshiftHelperStatusTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/OpenshiftHelperStatusTest.java
@@ -80,7 +80,7 @@ public class OpenshiftHelperStatusTest {
             return Arrays.asList(new Object[][]{
                     {"IsFailTrue", "Fail", true},
                     {"IsErrorTrue", "Error", true},
-                    {"IsNullFalse","null",false}
+                    {"IsNullFalse", "null",false}
             });
         }
 

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/OpenshiftHelperStatusTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/OpenshiftHelperStatusTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jkube.kit.common.util;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.function.BooleanSupplier;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,49 +25,35 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class OpenshiftHelperStatusTest {
-  @Parameterized.Parameters(name = "{index} OpenShift Status: '{0}'")
+  @Parameterized.Parameters(name = "{0} - {2}")
   public static Collection<Object[]> data() {
     return Arrays.asList(
-        // input, isFinished, isCancelled, isFailed, isCompleted
-        new Object[] { "Complete", true, false, false, true },
-        new Object[] { "Error", true, false, true, false },
-        new Object[] { "Cancelled", true, true, false, false },
-        new Object[] { "not Complete", false, false, false, false },
-        new Object[] { null, false, false, false, false });
+        // input, method, expectedValue
+        new Object[] { "IsCancelledTrue", (BooleanSupplier)(() -> OpenshiftHelper.isCancelled("Cancelled")), true},
+        new Object[] { "IsCancelledFalse", (BooleanSupplier)(() -> OpenshiftHelper.isCancelled("not Cancelled")), false},
+        new Object[] { "IsFailedTrueWithFail", (BooleanSupplier)(() -> OpenshiftHelper.isFailed("Fail")), true},
+        new Object[] { "IsFailedTrueWithError", (BooleanSupplier)(() -> OpenshiftHelper.isFailed("Error")), true},
+        new Object[] { "IsFailedFalse", (BooleanSupplier)(() -> OpenshiftHelper.isFailed(null)), false},
+        new Object[] { "IsCompletedTrue", (BooleanSupplier)(() -> OpenshiftHelper.isCompleted("Complete")), true},
+        new Object[] { "IsCompletedFalse", (BooleanSupplier)(() -> OpenshiftHelper.isCompleted("not Complete")), false},
+        new Object[] { "IsFinishedComplete", (BooleanSupplier)(() -> OpenshiftHelper.isFinished("Complete")), true},
+        new Object[] { "IsFinishedFailed", (BooleanSupplier)(() -> OpenshiftHelper.isFinished("Error")), true},
+        new Object[] { "IsFinishedCancelled", (BooleanSupplier)(() -> OpenshiftHelper.isFinished("Cancelled")), true},
+        new Object[] { "IsFinishedFalse", (BooleanSupplier)(() -> OpenshiftHelper.isFinished("not Complete")), false}
+    );
   }
 
   @Parameterized.Parameter
   public String input;
-  @Parameterized.Parameter(1)
-  public boolean isFinished;
-  @Parameterized.Parameter(2)
-  public boolean isCancelled;
-  @Parameterized.Parameter(3)
-  public boolean isFailed;
-  @Parameterized.Parameter(4)
-  public boolean isCompleted;
+
+  @Parameterized.Parameter (1)
+  public BooleanSupplier statusSupplier;
+
+  @Parameterized.Parameter (2)
+  public boolean expectedValue;
 
   @Test
-  public void testIsFinished() {
-    boolean result = OpenshiftHelper.isFinished(input);
-    assertThat(result).isEqualTo(isFinished);
-  }
-
-  @Test
-  public void testIsCancelled() {
-    boolean result = OpenshiftHelper.isCancelled(input);
-    assertThat(result).isEqualTo(isCancelled);
-  }
-
-  @Test
-  public void testIsFailed() {
-    boolean result = OpenshiftHelper.isFailed(input);
-    assertThat(result).isEqualTo(isFailed);
-  }
-
-  @Test
-  public void testIsCompleted() {
-    boolean result = OpenshiftHelper.isCompleted(input);
-    assertThat(result).isEqualTo(isCompleted);
+  public void testOpenShiftStatus() {
+    assertThat(statusSupplier.getAsBoolean()).isEqualTo(expectedValue);
   }
 }


### PR DESCRIPTION
## Description

Use BooleanSupplier so that we don't need to create separate tests over for all boolean OpenShiftHelper status related methods.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->