### PR TITLE
fix (openshift-maven-plugin/plugin) : Move mockServiceHub mock initialization to set up method

### DIFF
--- a/openshift-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/OpenshiftUndeployMojoTest.java
+++ b/openshift-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/OpenshiftUndeployMojoTest.java
@@ -21,7 +21,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.Mock;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,7 +30,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 
 public class OpenshiftUndeployMojoTest {
 
@@ -45,6 +43,7 @@ public class OpenshiftUndeployMojoTest {
 
   @Before
   public void setUp() throws IOException {
+    mockServiceHub = mock(JKubeServiceHub.class);
     kubernetesManifestFile = temporaryFolder.newFile();
     openShiftManifestFile = temporaryFolder.newFile();
     openShiftISManifestFile = temporaryFolder.newFile();
@@ -58,8 +57,7 @@ public class OpenshiftUndeployMojoTest {
 
   @Test
   public void getManifestsToUndeploy() {
-    KubernetesClient client= mock(KubernetesClient.class,RETURNS_DEEP_STUBS);
-    mockServiceHub=mock(JKubeServiceHub.class);
+    KubernetesClient client = mock(KubernetesClient.class, RETURNS_DEEP_STUBS);
     // Given
     when(mockServiceHub.getClient()).thenReturn(client);
     when(client.isAdaptable(OpenShiftClient.class)).thenReturn(true);


### PR DESCRIPTION
# Description
`mockServiceHub` should be initialized in `@Before` setUp method instead of within test, it's assigned to `OpenShiftUndeployMojo.jkubeServiceHub` in setUp method later.

Right now we're doing this within `getManifestsToUndeploy` test but till then `OpenShiftUndeploy.jkubeServiceHub` gets initialized to `null` which causes the test to fail.


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
