### PR TITLE
fix (jkube-kit/enricher/specific) : Remove unnecessary mockConstruction usages from DockerHealthCheckEnricherTest & PrometheusEnricherTest

### DIFF
--- a/jkube-kit/enricher/specific/src/test/java/org/eclipse/jkube/kit/enricher/specific/PrometheusEnricherTest.java
+++ b/jkube-kit/enricher/specific/src/test/java/org/eclipse/jkube/kit/enricher/specific/PrometheusEnricherTest.java
@@ -27,13 +27,10 @@ import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.MockedConstruction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unused")
@@ -45,39 +42,35 @@ public class PrometheusEnricherTest {
   public void setUp() {
     context = mock(JKubeEnricherContext.class,RETURNS_DEEP_STUBS);
   }
-  @SuppressWarnings("ResultOfMethodCallIgnored")
+
   private void initContext(ProcessorConfig config, ImageConfiguration imageConfiguration) {
     when(context.getConfiguration()).thenReturn(Configuration.builder().processorConfig(config).image(imageConfiguration).build());
   }
 
   @Test
   public void testCustomPrometheusPort() {
-    try (MockedConstruction<PrometheusEnricher> mockedConstruction = mockConstruction(PrometheusEnricher.class)) {
-      context = mock(JKubeEnricherContext.class,RETURNS_DEEP_STUBS);
-      PrometheusEnricher prometheusEnricher = new PrometheusEnricher(context);
-      // Given
-      initContext(new ProcessorConfig(
-                      null,
-                      null,
-                      Collections.singletonMap("jkube-prometheus", Collections.singletonMap("prometheusPort", "1234"))),
-              null);
-      final KubernetesListBuilder builder = new KubernetesListBuilder().withItems(
-              new ServiceBuilder().withNewMetadata().withName("foo").endMetadata().build()
-      );
-      // When
-      prometheusEnricher.create(PlatformMode.kubernetes, builder);
-      // Then
-      assertThat(builder.buildFirstItem().getMetadata().getAnnotations())
-              .hasSize(3)
-              .containsEntry("prometheus.io/port", "1234")
-              .containsEntry("prometheus.io/scrape", "true")
-              .containsEntry("prometheus.io/path", "/metrics");
-    }
+    PrometheusEnricher prometheusEnricher = new PrometheusEnricher(context);
+    // Given
+    initContext(new ProcessorConfig(
+            null,
+            null,
+            Collections.singletonMap("jkube-prometheus", Collections.singletonMap("prometheusPort", "1234"))),
+        null);
+    final KubernetesListBuilder builder = new KubernetesListBuilder().withItems(
+        new ServiceBuilder().withNewMetadata().withName("foo").endMetadata().build()
+    );
+    // When
+    prometheusEnricher.create(PlatformMode.kubernetes, builder);
+    // Then
+    assertThat(builder.buildFirstItem().getMetadata().getAnnotations())
+        .hasSize(3)
+        .containsEntry("prometheus.io/port", "1234")
+        .containsEntry("prometheus.io/scrape", "true")
+        .containsEntry("prometheus.io/path", "/metrics");
   }
 
   @Test
   public void testDetectPrometheusPort() {
-    try (MockedConstruction<PrometheusEnricher> ignore = mockConstruction(PrometheusEnricher.class)) {
       // Given
       initContext(null,
               ImageConfiguration.builder().build(
@@ -90,19 +83,17 @@ public class PrometheusEnricherTest {
       );
       PrometheusEnricher prometheusEnricher = new PrometheusEnricher(context);
       // When
-      doNothing().when(prometheusEnricher).create(PlatformMode.kubernetes, builder);
+      prometheusEnricher.create(PlatformMode.kubernetes, builder);
       // Then
       assertThat(builder.buildFirstItem().getMetadata().getAnnotations())
               .hasSize(3)
               .containsEntry("prometheus.io/port", "9779")
               .containsEntry("prometheus.io/scrape", "true")
               .containsEntry("prometheus.io/path", "/metrics");
-    }
   }
 
   @Test
   public void testNoDefinedPrometheusPort() {
-    try (MockedConstruction<PrometheusEnricher> ignore = mockConstruction(PrometheusEnricher.class)) {
       // Given
       initContext(null,
               ImageConfiguration.builder().build(
@@ -118,35 +109,31 @@ public class PrometheusEnricherTest {
       prometheusEnricher.create(PlatformMode.kubernetes, builder);
       // Then
       assertThat(builder.buildFirstItem().getMetadata().getAnnotations()).isNull();
-    }
   }
 
   @Test
   public void testCustomPrometheusPath() {
-    try (MockedConstruction<PrometheusEnricher> ignore = mockConstruction(PrometheusEnricher.class)) {
-
-      // Given
-      initContext(new ProcessorConfig(
-                      null,
-                      null,
-                      Collections.singletonMap("jkube-prometheus", Collections.singletonMap("prometheusPath", "/prometheus"))),
-              ImageConfiguration.builder().build(
-                              BuildConfiguration.builder()
-                                      .ports(Arrays.asList("1337", null, " ", "9779", null))
-                                      .build())
-                      .build());
-      final KubernetesListBuilder builder = new KubernetesListBuilder().withItems(
-              new ServiceBuilder().withNewMetadata().withName("foo").endMetadata().build()
-      );
-      PrometheusEnricher prometheusEnricher = new PrometheusEnricher(context);
-      // When
-      prometheusEnricher.create(PlatformMode.kubernetes, builder);
-      // Then
-      assertThat(builder.buildFirstItem().getMetadata().getAnnotations())
-              .hasSize(3)
-              .containsEntry("prometheus.io/port", "9779")
-              .containsEntry("prometheus.io/scrape", "true")
-              .containsEntry("prometheus.io/path", "/prometheus");
-    }
+    // Given
+    initContext(new ProcessorConfig(
+            null,
+            null,
+            Collections.singletonMap("jkube-prometheus", Collections.singletonMap("prometheusPath", "/prometheus"))),
+        ImageConfiguration.builder().build(
+                BuildConfiguration.builder()
+                    .ports(Arrays.asList("1337", null, " ", "9779", null))
+                    .build())
+            .build());
+    final KubernetesListBuilder builder = new KubernetesListBuilder().withItems(
+        new ServiceBuilder().withNewMetadata().withName("foo").endMetadata().build()
+    );
+    PrometheusEnricher prometheusEnricher = new PrometheusEnricher(context);
+    // When
+    prometheusEnricher.create(PlatformMode.kubernetes, builder);
+    // Then
+    assertThat(builder.buildFirstItem().getMetadata().getAnnotations())
+        .hasSize(3)
+        .containsEntry("prometheus.io/port", "9779")
+        .containsEntry("prometheus.io/scrape", "true")
+        .containsEntry("prometheus.io/path", "/prometheus");
   }
 }


### PR DESCRIPTION
## Description

We're not supposed to mock objects we're testing. `mockConstruction` is
useful when an object (used by class getting tested) gets created in between
the call made by a method. It's useful in cases where objects created
via `mock` can't be passed directly.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>



## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
